### PR TITLE
#25-fix: cors headers for react dev env

### DIFF
--- a/decide/administration/frontend/src/api/axios.ts
+++ b/decide/administration/frontend/src/api/axios.ts
@@ -6,18 +6,11 @@ const API_URL = "http://localhost:8000/administration/api";
 
 export const axios = Axios.create({
   baseURL: API_URL,
-});
-
-// Headers interceptor
-axios.interceptors.request.use((config: AxiosRequestConfig) => {
-  if (config.headers) {
-    // content-type
-    config.headers.Accept = "application/json";
-    config.headers.ContentType = "application/json";
-    config.headers["Access-Control-Allow-Origin"] = "*";
-  }
-
-  return config;
+  withCredentials: true,
+  headers: {
+    "Content-Type": "application/json",
+    Accept: "application/json",
+  },
 });
 
 // Auth interceptor (logout)

--- a/decide/administration/frontend/src/api/axios.ts
+++ b/decide/administration/frontend/src/api/axios.ts
@@ -1,4 +1,4 @@
-import Axios, { AxiosRequestConfig } from "axios";
+import Axios from "axios";
 
 import { sessionUtils } from "utils";
 

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -24,15 +24,6 @@ SECRET_KEY = '^##ydkswfu0+=ofw0l#$kv^8n)0$i(qd&d&ol#p9!b$8*5%j1+'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
-ALLOW_CREDENTIALS = True
-
-CORS_ORIGIN_ALLOW_ALL = True
-CORS_ORIGIN_WHITELIST = (
-    'http://localhost:3000/#',
-    'http://localhost:8000/#',
-)
-CORS_ALLOW_HEADERS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
@@ -62,6 +53,7 @@ REST_FRAMEWORK = {
 AUTHENTICATION_BACKENDS = [
     'base.backends.AuthBackend',
 ]
+
 
 MODULES = [
     'administration',
@@ -194,4 +186,3 @@ if os.path.exists("config.jsonnet"):
         vars()[k] = v
 
 INSTALLED_APPS = INSTALLED_APPS + MODULES
-# added to solve CORS

--- a/decide/local_settings.py
+++ b/decide/local_settings.py
@@ -1,10 +1,18 @@
+# dev env CORS SETTINGS
+BASEURL = 'http://localhost:8000'
+FE_BASEURL = 'http://localhost:3000'
 
 ALLOWED_HOSTS = ['*']
 
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
+CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = (
-    'http://localhost:3000',
+    BASEURL, FE_BASEURL
 )
+CSRF_TRUSTED_ORIGINS = [
+    BASEURL, FE_BASEURL
+]
+
 
 # Modules in use, commented modules that you won't use
 MODULES = [
@@ -20,7 +28,6 @@ MODULES = [
     'voting',
 ]
 
-BASEURL = 'http://localhost:8000'
 
 APIS = {
     'administration': BASEURL,
@@ -42,14 +49,6 @@ DATABASES = {
         'CLIENT': {
             'host': '127.0.0.1',
         }
-    },
-    'postgres': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'postgres',
-        'USER': 'decide',
-        'PASSWORD': 'decide',
-        'HOST': '127.0.0.1',
-        'PORT': '5432',
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django-utils==0.0.2
 Django==2.2.5
 pycryptodome==3.6.6
 djangorestframework==3.7.7
-django-cors-headers==2.1.0
+django-cors-headers==3.0.1
 requests==2.23.0
 django-filter==21.1
 psycopg2-binary==2.8.6


### PR DESCRIPTION
closes #25 

## changes
- fix CORS headers

## test
- desplegar django en local
- desplegar react en modo desarrollo
    - desde `./administration/frontend`
    - `npm run install`
    - `npm start`
- ir a `localhost:3000`
- hacer login
- ir a usuarios
- comprobar que aparecen usuarios 